### PR TITLE
fix: use sha256, apply `sc_reduce32` and change salt in key derivation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -848,7 +848,7 @@ dependencies = [
  "hex",
  "pbkdf2",
  "rand_core",
- "sha3",
+ "sha2",
  "std-shims",
  "subtle",
  "thiserror",

--- a/polyseed/Cargo.toml
+++ b/polyseed/Cargo.toml
@@ -24,7 +24,7 @@ subtle = { version = "^2.4", default-features = false }
 zeroize = { version = "^1.5", default-features = false, features = ["zeroize_derive"] }
 rand_core = { version = "0.6", default-features = false }
 
-sha3 = { version = "0.10", default-features = false }
+sha2 = { version = "0.10.8", default-features = false }
 pbkdf2 = { version = "0.12", features = ["simple"], default-features = false }
 
 [dev-dependencies]
@@ -40,7 +40,7 @@ std = [
   "zeroize/std",
   "rand_core/std",
 
-  "sha3/std",
+  "sha2/std",
   "pbkdf2/std",
 ]
 default = ["std"]

--- a/polyseed/src/lib.rs
+++ b/polyseed/src/lib.rs
@@ -12,7 +12,7 @@ use subtle::ConstantTimeEq;
 use zeroize::{Zeroize, Zeroizing, ZeroizeOnDrop};
 use rand_core::{RngCore, CryptoRng};
 
-use sha3::Sha3_256;
+use sha2::Sha256;
 use pbkdf2::pbkdf2_hmac;
 
 #[cfg(test)]
@@ -439,10 +439,17 @@ impl Polyseed {
 
   /// The key derived from this seed.
   pub fn key(&self) -> Zeroizing<[u8; 32]> {
-    let mut key = Zeroizing::new([0; 32]);
-    pbkdf2_hmac::<Sha3_256>(
+    let mut key = Zeroizing::new([0u8; 32]);
+    let mut salt = [0u8; 32];
+    salt[..12].copy_from_slice(POLYSEED_SALT);
+    salt[13] = 0xFF;
+    salt[14] = 0xFF;
+    salt[15] = 0xFF;
+    salt[20] = self.birthday.try_into().unwrap();
+    salt[24] = self.features;
+    pbkdf2_hmac::<Sha256>(
       self.entropy.as_slice(),
-      POLYSEED_SALT,
+      &salt,
       POLYSEED_KEYGEN_ITERATIONS,
       key.as_mut(),
     );

--- a/polyseed/src/tests.rs
+++ b/polyseed/src/tests.rs
@@ -216,3 +216,11 @@ fn test_invalid_polyseed() {
   let res = Polyseed::from_string(Language::English, Zeroizing::new(seed));
   assert_eq!(res, Err(PolyseedError::UnsupportedFeatures));
 }
+
+#[test]
+fn test_key() {
+  let seed: String = "comic blanket chair inject end snow rural improve cereal better initial replace ribbon brother gather unaware".into();
+  let res = Polyseed::from_string(Language::English, Zeroizing::new(seed)).unwrap();
+  let key = res.key();
+  assert_eq!(*key, [216, 82, 37, 164, 252, 122, 170, 61, 52, 152, 131, 26, 181, 226, 191, 131, 204, 3, 242, 225, 229, 175, 37, 151, 18, 143, 53, 175, 136, 17, 47, 126]);
+}

--- a/seed/src/lib.rs
+++ b/seed/src/lib.rs
@@ -323,11 +323,8 @@ impl Seed {
     let entropy = seed_to_bytes(lang, &words)?;
 
     // Make sure this is a valid scalar
-    let scalar = Scalar::from_canonical_bytes(*entropy);
-    if scalar.is_none().into() {
-      Err(SeedError::InvalidSeed)?;
-    }
-    let mut scalar = scalar.unwrap();
+    let scalar = Scalar::from_bytes_mod_order(*entropy);
+    let mut scalar = scalar;
     scalar.zeroize();
 
     // Call from_entropy so a trimmed seed becomes a full seed
@@ -337,7 +334,7 @@ impl Seed {
   /// Create a seed from entropy.
   #[allow(clippy::needless_pass_by_value)]
   pub fn from_entropy(lang: Language, entropy: Zeroizing<[u8; 32]>) -> Option<Seed> {
-    Option::from(Scalar::from_canonical_bytes(*entropy))
+    Option::from(Scalar::from_bytes_mod_order(*entropy))
       .map(|scalar| key_to_seed(lang, Zeroizing::new(scalar)))
   }
 


### PR DESCRIPTION
Change `Sha3_256` to `Sha256` and make necessary changes to salt.

Take a look at Cake Wallet's polyseed implementation in Dart:

https://github.com/cake-tech/polyseed_dart/blob/cc3092ef0289c45520a098becb2ee8fb25adf50f/lib/src/polyseed.dart#L174-L195

We also need to add coin index to the 17th byte of salt but it is not necessary as this crate is only for Monero.

EDIT (25.02.2025):

Also added applying `sc_reduce32` instead of direct convertion. Direct version gives error even if the entropy is correct.